### PR TITLE
 update iota_client_core_init

### DIFF
--- a/bazel_template/WORKSPACE
+++ b/bazel_template/WORKSPACE
@@ -4,19 +4,19 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "org_iota_common",
-    commit = "6eb68fd38288fb96b1ecedbb1d2844516be596b9",
+    commit = "82818daf1ffa31b0f8a247ec51eee5cf68cb79ab",
     remote = "https://github.com/iotaledger/iota_common.git",
 )
 
 git_repository(
     name = "org_iota_client",
-    commit = "a3dfd78c685d8805ccd586f603037d205c26a57d",
+    commit = "d632a84272dab322e9fbcbe71a5e6ac7e8168900",
     remote = "https://github.com/iotaledger/iota.c.git",
 )
 
 git_repository(
     name = "rules_iota",
-    commit = "e08b0038f376d6c82b80f5283bb0a86648bb58dc",
+    commit = "4fd742195c31b9e2bf859a68cd5de4b2fdba7086",
     remote = "https://github.com/iotaledger/rules_iota.git",
 )
 

--- a/bazel_template/my_app.c
+++ b/bazel_template/my_app.c
@@ -2,23 +2,6 @@
 #include "cclient/api/extended/extended_api.h"
 #include "config.h"
 
-void init_iota_client(iota_client_service_t *const service) {
-  service->http.path = "/";
-  service->http.content_type = "application/json";
-  service->http.accept = "application/json";
-  service->http.host = CONFIG_IRI_NODE_URI;
-  service->http.port = CONFIG_IRI_NODE_PORT;
-  service->http.api_version = 1;
-#ifdef CONFIG_ENABLE_HTTPS
-  service->http.ca_pem = ROOT_CA1_PEM;
-#else
-  service->http.ca_pem = NULL;
-#endif
-  service->serializer_type = SR_JSON;
-  iota_client_core_init(service);
-  iota_client_extended_init();
-}
-
 void get_iota_node_info(iota_client_service_t *iota_client_service) {
   retcode_t ret = RC_ERROR;
   // Allocate a response object
@@ -63,9 +46,14 @@ done:
 
 int main(void) {
   // Create and init the client service
-  iota_client_service_t iota_client_service;
-  init_iota_client(&iota_client_service);
+  iota_client_service_t *iota_client_service;
+
+#ifdef CONFIG_ENABLE_HTTPS
+    iota_client_service = iota_client_core_init(CONFIG_IRI_NODE_URI, CONFIG_IRI_NODE_PORT, ROOT_CA1_PEM);
+#else
+    iota_client_service = iota_client_core_init(CONFIG_IRI_NODE_URI, CONFIG_IRI_NODE_PORT, NULL);
+#endif
 
   // Call the getNodeInfo endpoint
-  get_iota_node_info(&iota_client_service);
+  get_iota_node_info(iota_client_service);
 }

--- a/cmake_template/CMakeLists.txt
+++ b/cmake_template/CMakeLists.txt
@@ -12,7 +12,7 @@ include(FetchContent)
 FetchContent_Declare(
   iota.c
   GIT_REPOSITORY http://github.com/iotaledger/iota.c.git
-  GIT_TAG a3dfd78c685d8805ccd586f603037d205c26a57d
+  GIT_TAG d632a84272dab322e9fbcbe71a5e6ac7e8168900
 )
 
 if(${CMAKE_VERSION} VERSION_LESS 3.14)

--- a/cmake_template/my_app.c
+++ b/cmake_template/my_app.c
@@ -2,23 +2,6 @@
 #include "cclient/api/extended/extended_api.h"
 #include "config.h"
 
-void init_iota_client(iota_client_service_t *const service) {
-  service->http.path = "/";
-  service->http.content_type = "application/json";
-  service->http.accept = "application/json";
-  service->http.host = CONFIG_IRI_NODE_URI;
-  service->http.port = CONFIG_IRI_NODE_PORT;
-  service->http.api_version = 1;
-#ifdef CONFIG_ENABLE_HTTPS
-  service->http.ca_pem = ROOT_CA1_PEM;
-#else
-  service->http.ca_pem = NULL;
-#endif
-  service->serializer_type = SR_JSON;
-  iota_client_core_init(service);
-  iota_client_extended_init();
-}
-
 void get_iota_node_info(iota_client_service_t *iota_client_service) {
   retcode_t ret = RC_ERROR;
   // Allocate a response object
@@ -63,9 +46,14 @@ done:
 
 int main(void) {
   // Create and init the client service
-  iota_client_service_t iota_client_service;
-  init_iota_client(&iota_client_service);
+  iota_client_service_t *iota_client_service;
+
+#ifdef CONFIG_ENABLE_HTTPS
+    iota_client_service = iota_client_core_init(CONFIG_IRI_NODE_URI, CONFIG_IRI_NODE_PORT, ROOT_CA1_PEM);
+#else
+    iota_client_service = iota_client_core_init(CONFIG_IRI_NODE_URI, CONFIG_IRI_NODE_PORT, NULL);
+#endif
 
   // Call the getNodeInfo endpoint
-  get_iota_node_info(&iota_client_service);
+  get_iota_node_info(iota_client_service);
 }


### PR DESCRIPTION
`iota_client_core_init` signature changed (no more `*const service`)
this PR makes the examples up-to-date with `iota.c`'s `CClient` API